### PR TITLE
Tests coverage is now displayed as a PR comment

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -1,15 +1,17 @@
 name: Tests
 
 on:
-  push:
-  pull_request:
-    branches:
-      - "*"       # Trigger on any branch with a pull request
-      - "!main"   # Exclude the main branch
+  pull_request:  # Ejecutar en todas las Pull Requests
     types:
       - opened
       - synchronize
+      - reopened
+  push:  # Ejecutar solo en ramas específicas
+    branches:
+      - main
+      - dev
 
+  
 env:
   APP_NAME: BookHub
   DB_HOST: localhost
@@ -21,6 +23,14 @@ env:
 jobs:
 
   test:
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for pushing data to the
+      # python-coverage-comment-action branch, and for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
     runs-on: ubuntu-latest
     services:
       mysql:
@@ -75,9 +85,17 @@ jobs:
       run: |
         cd backend
         poetry run alembic upgrade head
-        poetry run pytest
+        poetry run pytest --cov=app --cov-report=xml:coverage.xml
+
     - name: Store coverage files
       uses: actions/upload-artifact@v4
       with:
         name: coverage-html
         path: backend/htmlcov
+
+    - name: Get Cover 
+      uses: orgoro/coverage@v3.2
+      continue-on-error: true
+      with:
+          coverageFile: backend/coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Add Python Test Coverage in PR Comments

## Description

This PR updates the GitHub Actions workflow to calculate Python test coverage and post the results as a comment on pull requests. The comment includes coverage details (total and per file) to improve visibility and promote better testing practices.

## Key Changes

- Run tests with `pytest` and calculate coverage using `pytest-cov`.
- Generate and format a coverage report.
- Post coverage details to the PR via the GitHub Actions bot.

## Testing

- Verified functionality on test PRs with various coverage scenarios.
- Ensured the workflow handles test failures gracefully.

## Notes

- Automatically triggers for new and updated PRs.
